### PR TITLE
update to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ Because of limitations of `std::io::Error` type, `genio` provides `Read` and
 `Write` traits that allow implementors to choose their own type. This type can
 be better at expressing what kinds of error can happen.
 """
+edition = "2018"
 
 [dependencies]
 void = { version = "1", default-features = false }

--- a/src/bufio.rs
+++ b/src/bufio.rs
@@ -1,9 +1,9 @@
 //! Contains traits and impls for buffering.
 
-use ::void::Void;
-use error::BufError;
-use Read;
-use Write;
+use crate::error::BufError;
+use crate::Read;
+use crate::Write;
+use void::Void;
 
 /// A `BufRead` is a type of `Read`er which has an internal buffer, allowing it to perform extra ways
 /// of reading.
@@ -252,7 +252,7 @@ unsafe impl<'a> BufWrite for &'a mut [u8] {
         if self.len() > 0 {
             Ok(*self)
         } else {
-            Err(::error::BufferOverflow)
+            Err(crate::error::BufferOverflow)
         }
     }
 

--- a/src/bufio.rs
+++ b/src/bufio.rs
@@ -1,16 +1,16 @@
 //! Contains traits and impls for buffering.
 
+use ::void::Void;
+use error::BufError;
 use Read;
 use Write;
-use error::BufError;
-use ::void::Void;
 
 /// A `BufRead` is a type of `Read`er which has an internal buffer, allowing it to perform extra ways
 /// of reading.
 pub trait BufRead: Read {
     /// Fills the internal buffer of this object, returning the buffer contents.
     /// This function is a lower-level call. It needs to be paired with the consume() method to
-    /// function properly. 
+    /// function properly.
     fn fill_buf(&mut self) -> Result<&[u8], Self::ReadError>;
     /// Tells this buffer that `amount` bytes have been consumed from the buffer, so they should no
     /// longer be returned in calls to `read`.
@@ -63,13 +63,19 @@ pub trait BufReadRequire: BufRead {
     type BufReadError;
 
     /// Fill the buffer until at least `amount` bytes are available.
-    fn require_bytes(&mut self, amount: usize) -> Result<&[u8], BufError<Self::BufReadError, Self::ReadError>>;
+    fn require_bytes(
+        &mut self,
+        amount: usize,
+    ) -> Result<&[u8], BufError<Self::BufReadError, Self::ReadError>>;
 }
 
 impl<'a> BufReadRequire for &'a [u8] {
     type BufReadError = Void;
 
-    fn require_bytes(&mut self, amount: usize) -> Result<&[u8], BufError<Self::BufReadError, Self::ReadError>> {
+    fn require_bytes(
+        &mut self,
+        amount: usize,
+    ) -> Result<&[u8], BufError<Self::BufReadError, Self::ReadError>> {
         if amount <= self.len() {
             Ok(*self)
         } else {
@@ -113,7 +119,7 @@ pub unsafe trait BufWriteRequire: BufWrite {
     type BufWriteError;
 
     /// Require buffer with minimum `size` bytes. It is an error to return smaller buffer but
-    /// `unsafe` code can't rely on it. 
+    /// `unsafe` code can't rely on it.
     fn require_buffer(&mut self, size: usize) -> Result<*mut [u8], Self::BufWriteError>;
 }
 
@@ -198,9 +204,7 @@ impl<W: Write, B: AsRawBuf> Write for BufWriter<W, B> {
 
     fn flush(&mut self) -> Result<(), Self::FlushError> {
         // This is correct because it gets slice to initialized data
-        let buf = unsafe {
-            &mut (*self.buffer.as_raw_buf())[0..self.cursor]
-        };
+        let buf = unsafe { &mut (*self.buffer.as_raw_buf())[0..self.cursor] };
 
         self.cursor = 0;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 //! Error types and various operations on them.
 
-use void::Void;
-use void;
 use ::core::fmt;
+use void;
+use void::Void;
 
 /// Specifies an error that happened during I/O operation. This enables one to compose read and
 /// write errors into single type.
@@ -18,7 +18,11 @@ pub enum IOError<R, W> {
 
 impl<R, W> IOError<R, W> {
     /// Merges the variants into common type.
-    pub fn merge<E>(e: IOError<R, W>) -> E where R: Into<E>, W: Into<E> {
+    pub fn merge<E>(e: IOError<R, W>) -> E
+    where
+        R: Into<E>,
+        W: Into<E>,
+    {
         match e {
             IOError::Read(e) => e.into(),
             IOError::Write(e) => e.into(),
@@ -74,7 +78,11 @@ pub enum ChainError<F, S> {
 impl<F, S> ChainError<F, S> {
     /// If the two errors can be converted to same type, they can be easily merged by this method.
     /// This simply performs the conversion.
-    pub fn merge<E>(self) -> E where F: Into<E>, S: Into<E> {
+    pub fn merge<E>(self) -> E
+    where
+        F: Into<E>,
+        S: Into<E>,
+    {
         match self {
             ChainError::First(f) => f.into(),
             ChainError::Second(s) => s.into(),

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,7 +1,7 @@
 //! This module contains various extension traits.
 
-use error::ReadExactError;
-use Read;
+use crate::error::ReadExactError;
+use crate::Read;
 
 /// Result of successful read operation.
 pub enum ReadResult<'a> {

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,7 +1,7 @@
 //! This module contains various extension traits.
 
-use Read;
 use error::ReadExactError;
+use Read;
 
 /// Result of successful read operation.
 pub enum ReadResult<'a> {
@@ -56,11 +56,15 @@ impl<'a> ReadResult<'a> {
 /// }
 pub trait ReadExt: Read {
     /// Reads from the reader and converts the result.
-    fn read_ext<'a, 'b>(&'a mut self, buf: &'b mut [u8]) -> Result<ReadResult<'b>, Self::ReadError>;
+    fn read_ext<'a, 'b>(&'a mut self, buf: &'b mut [u8])
+        -> Result<ReadResult<'b>, Self::ReadError>;
 }
 
 impl<R: Read + ?Sized> ReadExt for R {
-    fn read_ext<'a, 'b>(&'a mut self, buf: &'b mut [u8]) -> Result<ReadResult<'b>, Self::ReadError> {
+    fn read_ext<'a, 'b>(
+        &'a mut self,
+        buf: &'b mut [u8],
+    ) -> Result<ReadResult<'b>, Self::ReadError> {
         let len = self.read(buf)?;
         if len > 0 {
             Ok(ReadResult::Bytes(&mut buf[..len]))
@@ -69,4 +73,3 @@ impl<R: Read + ?Sized> ReadExt for R {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub mod error;
 pub mod ext;
 pub mod util;
 
-use error::{ExtendError, ReadExactError};
+use crate::error::{ExtendError, ReadExactError};
 use util::Chain;
 use void::Void;
 
@@ -473,7 +473,7 @@ impl<'a> Read for &'a [u8] {
     type ReadError = Void;
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
-        use ::core::cmp::min;
+        use core::cmp::min;
 
         let amt = min(buf.len(), self.len());
         let (a, b) = self.split_at(amt);

--- a/src/std_impls.rs
+++ b/src/std_impls.rs
@@ -1,16 +1,16 @@
 //! This module contains glue `for std::io` and other `std` types.
 
-use bufio::BufWrite;
-use error::ExtendError;
+use crate::bufio::BufWrite;
+use crate::error::ExtendError;
+use crate::ExtendFromReader;
+use crate::ExtendFromReaderSlow;
+use crate::Read;
+use crate::ReadOverwrite;
+use crate::Write;
 use std::io;
 use std::io::{Empty, Sink};
 use std::vec::Vec;
 use void::Void;
-use ExtendFromReader;
-use ExtendFromReaderSlow;
-use Read;
-use ReadOverwrite;
-use Write;
 
 impl Write for Vec<u8> {
     type WriteError = Void;
@@ -36,7 +36,7 @@ impl Write for Vec<u8> {
 
 unsafe impl BufWrite for Vec<u8> {
     fn request_buffer(&mut self) -> Result<*mut [u8], Self::WriteError> {
-        use ::std::slice;
+        use std::slice;
 
         // Ensure there is a space for data
         self.reserve(1);

--- a/src/std_impls.rs
+++ b/src/std_impls.rs
@@ -1,16 +1,16 @@
 //! This module contains glue `for std::io` and other `std` types.
 
-use Read;
-use Write;
+use bufio::BufWrite;
+use error::ExtendError;
+use std::io;
+use std::io::{Empty, Sink};
+use std::vec::Vec;
+use void::Void;
 use ExtendFromReader;
 use ExtendFromReaderSlow;
-use error::ExtendError;
+use Read;
 use ReadOverwrite;
-use void::Void;
-use std::vec::Vec;
-use std::io::{Sink, Empty};
-use std::io;
-use bufio::BufWrite;
+use Write;
 
 impl Write for Vec<u8> {
     type WriteError = Void;
@@ -56,7 +56,10 @@ impl ExtendFromReaderSlow for Vec<u8> {
     // That means `Vec` can never fail.
     type ExtendError = Void;
 
-    fn extend_from_reader_slow<R: Read + ?Sized>(&mut self, reader: &mut R) -> Result<usize, ExtendError<R::ReadError, Self::ExtendError>> {
+    fn extend_from_reader_slow<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+    ) -> Result<usize, ExtendError<R::ReadError, Self::ExtendError>> {
         let begin = self.len();
         self.resize(begin + 1024, 0);
         match reader.read(&mut self[begin..]) {
@@ -67,19 +70,22 @@ impl ExtendFromReaderSlow for Vec<u8> {
                 assert!(bytes <= self.capacity() - begin);
                 self.resize(begin + bytes, 0);
                 Ok(bytes)
-            },
+            }
             Err(e) => {
                 // We have to reset len to previous value if error happens.
                 self.resize(begin, 0);
                 Err(ExtendError::ReadErr(e))
-            },
+            }
         }
     }
 }
 
 // Efficient implementation
 impl ExtendFromReader for Vec<u8> {
-    fn extend_from_reader<R: Read + ReadOverwrite + ?Sized>(&mut self, reader: &mut R) -> Result<usize, ExtendError<R::ReadError, Self::ExtendError>> {
+    fn extend_from_reader<R: Read + ReadOverwrite + ?Sized>(
+        &mut self,
+        reader: &mut R,
+    ) -> Result<usize, ExtendError<R::ReadError, Self::ExtendError>> {
         // Prepare space
         self.reserve(1024);
 
@@ -105,12 +111,12 @@ impl ExtendFromReader for Vec<u8> {
                         assert!(bytes <= capacity - begin);
                         self.set_len(begin + bytes);
                         Ok(bytes)
-                    },
+                    }
                     Err(e) => {
                         // We have to reset len to previous value if error happens.
                         self.set_len(begin);
                         Err(ExtendError::ReadErr(e))
-                    },
+                    }
                 }
             } else {
                 // Fallback for cases where `reserve` reserves nothing.
@@ -133,8 +139,7 @@ impl Write for Sink {
         Ok(())
     }
 
-    fn size_hint(&mut self, _bytes: usize) {
-    }
+    fn size_hint(&mut self, _bytes: usize) {}
 }
 
 // Same as our Empty.
@@ -147,7 +152,7 @@ impl Read for Empty {
 }
 
 /// Wrapper providing `std::io::Read` trait for `genio::Read` types.
-pub struct StdRead<R> (R);
+pub struct StdRead<R>(R);
 
 impl<R: Read> StdRead<R> {
     /// Wraps `genio` reader into `std` reader.
@@ -161,14 +166,14 @@ impl<R: Read> StdRead<R> {
     }
 }
 
-impl<E: Into<io::Error>, R: Read<ReadError=E>> io::Read for StdRead<R> {
+impl<E: Into<io::Error>, R: Read<ReadError = E>> io::Read for StdRead<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
         self.0.read(buf).map_err(Into::into)
     }
 }
 
 /// Wrapper providing `std::io::Write` trait for `genio::Write` types.
-pub struct StdWrite<W> (W);
+pub struct StdWrite<W>(W);
 
 impl<W: Write> StdWrite<W> {
     /// Wraps `genio` writer into `std` writer.
@@ -182,7 +187,9 @@ impl<W: Write> StdWrite<W> {
     }
 }
 
-impl<WE: Into<io::Error>, FE: Into<io::Error>, W: Write<WriteError=WE, FlushError=FE>> io::Write for StdWrite<W> {
+impl<WE: Into<io::Error>, FE: Into<io::Error>, W: Write<WriteError = WE, FlushError = FE>> io::Write
+    for StdWrite<W>
+{
     fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
         self.0.write(buf).map_err(Into::into)
     }
@@ -193,9 +200,15 @@ impl<WE: Into<io::Error>, FE: Into<io::Error>, W: Write<WriteError=WE, FlushErro
 }
 
 /// Wrapper providing `std::io::Read + std::io::Write` traits for `genio::Read + genio::Write` types.
-pub struct StdIo<T> (T);
+pub struct StdIo<T>(T);
 
-impl<RE: Into<io::Error>, WE: Into<io::Error>, FE: Into<io::Error>, T: Read<ReadError=RE> + Write<WriteError=WE, FlushError=FE>> StdIo<T> {
+impl<
+        RE: Into<io::Error>,
+        WE: Into<io::Error>,
+        FE: Into<io::Error>,
+        T: Read<ReadError = RE> + Write<WriteError = WE, FlushError = FE>,
+    > StdIo<T>
+{
     /// Wraps `genio` reader+writer into `std` reader+writer.
     pub fn new(io: T) -> Self {
         StdIo(io)
@@ -207,13 +220,15 @@ impl<RE: Into<io::Error>, WE: Into<io::Error>, FE: Into<io::Error>, T: Read<Read
     }
 }
 
-impl<E: Into<io::Error>, T: Read<ReadError=E>> io::Read for StdIo<T> {
+impl<E: Into<io::Error>, T: Read<ReadError = E>> io::Read for StdIo<T> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
         self.0.read(buf).map_err(Into::into)
     }
 }
 
-impl<WE: Into<io::Error>, FE: Into<io::Error>, T: Write<WriteError=WE, FlushError=FE>> io::Write for StdIo<T> {
+impl<WE: Into<io::Error>, FE: Into<io::Error>, T: Write<WriteError = WE, FlushError = FE>> io::Write
+    for StdIo<T>
+{
     fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
         self.0.write(buf).map_err(Into::into)
     }
@@ -224,7 +239,7 @@ impl<WE: Into<io::Error>, FE: Into<io::Error>, T: Write<WriteError=WE, FlushErro
 }
 
 /// Wrapper providing `genio::Read` trait for `std::io::Read` types.
-pub struct GenioRead<R> (R);
+pub struct GenioRead<R>(R);
 
 impl<R: io::Read> GenioRead<R> {
     /// Wraps `std` readerinto `genio` reader.
@@ -247,7 +262,7 @@ impl<R: io::Read> Read for GenioRead<R> {
 }
 
 /// Wrapper providing `genio::Write` trait for `std::io::Write` types.
-pub struct GenioWrite<W> (W);
+pub struct GenioWrite<W>(W);
 
 impl<W: io::Write> GenioWrite<W> {
     /// Wraps `std` writer into `genio` writer.
@@ -273,12 +288,11 @@ impl<W: io::Write> Write for GenioWrite<W> {
         self.0.flush()
     }
 
-    fn size_hint(&mut self, _bytes: usize) {
-    }
+    fn size_hint(&mut self, _bytes: usize) {}
 }
 
 /// Wrapper providing `genio::Read + genio::Write` traits for `std::io::Read + std::io::Write` types.
-pub struct GenioIo<T> (T);
+pub struct GenioIo<T>(T);
 
 impl<T: io::Read + io::Write> GenioIo<T> {
     /// Wraps `std` reader+writer into `genio` reader+writer.
@@ -312,6 +326,5 @@ impl<T: io::Write> Write for GenioIo<T> {
         self.0.flush()
     }
 
-    fn size_hint(&mut self, _bytes: usize) {
-    }
+    fn size_hint(&mut self, _bytes: usize) {}
 }

--- a/src/util/bytes.rs
+++ b/src/util/bytes.rs
@@ -10,9 +10,7 @@ pub struct Bytes<R> {
 impl<R: Read> Bytes<R> {
     /// Creates the iterator.
     pub fn new(reader: R) -> Self {
-        Bytes {
-            reader: reader,
-        }
+        Bytes { reader: reader }
     }
 }
 
@@ -26,5 +24,5 @@ impl<R: Read> Iterator for Bytes<R> {
             Ok(_) => Some(Ok(buf[0])),
             Err(e) => Some(Err(e)),
         }
-    } 
+    }
 }

--- a/src/util/bytes.rs
+++ b/src/util/bytes.rs
@@ -1,4 +1,4 @@
-use Read;
+use crate::Read;
 
 /// Represents reader as iterator over bytes.
 ///

--- a/src/util/chain.rs
+++ b/src/util/chain.rs
@@ -1,5 +1,5 @@
-use Read;
 use error::ChainError;
+use Read;
 
 /// Chains two readers.
 ///
@@ -27,19 +27,14 @@ impl<F: Read, S: Read> Read for Chain<F, S> {
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
         if self.first_finished {
-            self.second
-                .read(buf)
-                .map_err(ChainError::Second)
+            self.second.read(buf).map_err(ChainError::Second)
         } else {
-            self.first
-                .read(buf)
-                .map_err(ChainError::First)
-                .map(|l| {
-                    if l == 0 {
-                        self.first_finished = true;
-                    }
-                    l
-                })
+            self.first.read(buf).map_err(ChainError::First).map(|l| {
+                if l == 0 {
+                    self.first_finished = true;
+                }
+                l
+            })
         }
     }
 }

--- a/src/util/chain.rs
+++ b/src/util/chain.rs
@@ -1,5 +1,5 @@
-use error::ChainError;
-use Read;
+use crate::error::ChainError;
+use crate::Read;
 
 /// Chains two readers.
 ///

--- a/src/util/empty.rs
+++ b/src/util/empty.rs
@@ -1,14 +1,13 @@
-use Read;
 use void::Void;
+use Read;
 
 /// This reader is empty - always returns 0 from read method.
 pub struct Empty;
 
 impl Read for Empty {
     type ReadError = Void;
-    
+
     fn read(&mut self, _buf: &mut [u8]) -> Result<usize, Self::ReadError> {
         Ok(0)
     }
 }
-

--- a/src/util/empty.rs
+++ b/src/util/empty.rs
@@ -1,5 +1,5 @@
+use crate::Read;
 use void::Void;
-use Read;
 
 /// This reader is empty - always returns 0 from read method.
 pub struct Empty;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -20,8 +20,8 @@ pub use self::write_trunc::WriteTrunc;
 
 const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
-use error::IOError;
-use {Read, Write};
+use crate::error::IOError;
+use crate::{Read, Write};
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -39,7 +39,7 @@ pub fn copy<R: ?Sized + Read, W: ?Sized + Write>(
     reader: &mut R,
     writer: &mut W,
 ) -> Result<u64, IOError<R::ReadError, W::WriteError>> {
-    use ext::{ReadExt, ReadResult};
+    use crate::ext::{ReadExt, ReadResult};
 
     let mut buf = [0; DEFAULT_BUF_SIZE];
     let mut written = 0;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,27 +1,27 @@
 //! This module contains various generic utilities related to IO.
 
+mod bytes;
 mod chain;
-mod write_trunc;
-mod restarting;
-mod sink;
 mod empty;
 mod repeat;
 mod repeat_bytes;
-mod bytes;
+mod restarting;
+mod sink;
+mod write_trunc;
 
+pub use self::bytes::Bytes;
 pub use self::chain::Chain;
-pub use self::write_trunc::WriteTrunc;
-pub use self::restarting::Restarting;
-pub use self::sink::Sink;
 pub use self::empty::Empty;
 pub use self::repeat::Repeat;
 pub use self::repeat_bytes::RepeatBytes;
-pub use self::bytes::Bytes;
+pub use self::restarting::Restarting;
+pub use self::sink::Sink;
+pub use self::write_trunc::WriteTrunc;
 
 const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
-use {Read, Write};
 use error::IOError;
+use {Read, Write};
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -35,7 +35,10 @@ use error::IOError;
 /// This function will return an error immediately if any call to `read` or write returns an error.
 /// **Warning:** This function does not restart calls if they are interrupted by EINTR. Use
 /// `genio::util::Restarting` to restart calls.
-pub fn copy<R: ?Sized + Read, W: ?Sized + Write>(reader: &mut R, writer: &mut W) -> Result<u64, IOError<R::ReadError, W::WriteError>> {
+pub fn copy<R: ?Sized + Read, W: ?Sized + Write>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<u64, IOError<R::ReadError, W::WriteError>> {
     use ext::{ReadExt, ReadResult};
 
     let mut buf = [0; DEFAULT_BUF_SIZE];
@@ -47,4 +50,3 @@ pub fn copy<R: ?Sized + Read, W: ?Sized + Write>(reader: &mut R, writer: &mut W)
     }
     Ok(written)
 }
-

--- a/src/util/repeat.rs
+++ b/src/util/repeat.rs
@@ -1,5 +1,5 @@
+use crate::Read;
 use void::Void;
-use Read;
 
 /// Reader that infinitely repeats single byte.
 ///

--- a/src/util/repeat.rs
+++ b/src/util/repeat.rs
@@ -1,5 +1,5 @@
-use Read;
 use void::Void;
+use Read;
 
 /// Reader that infinitely repeats single byte.
 ///
@@ -10,7 +10,7 @@ pub struct Repeat {
 
 impl Read for Repeat {
     type ReadError = Void;
-    
+
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
         // TODO: use memset?
         let len = buf.len();

--- a/src/util/repeat_bytes.rs
+++ b/src/util/repeat_bytes.rs
@@ -1,5 +1,5 @@
-use Read;
 use void::Void;
+use Read;
 
 /// Reader repeating a sequence of bytes infinitely.
 pub struct RepeatBytes<B> {
@@ -9,7 +9,7 @@ pub struct RepeatBytes<B> {
 
 impl<B: AsRef<[u8]>> Read for RepeatBytes<B> {
     type ReadError = Void;
-    
+
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
         use ::core::cmp::min;
         let len = buf.len();
@@ -22,7 +22,10 @@ impl<B: AsRef<[u8]>> Read for RepeatBytes<B> {
             self.offset = 0
         }
 
-        let buf = { let tmp = &mut buf[amt..]; tmp };
+        let buf = {
+            let tmp = &mut buf[amt..];
+            tmp
+        };
 
         for chunk in buf.chunks_mut(bytes.len()) {
             if chunk.len() != bytes.len() {

--- a/src/util/repeat_bytes.rs
+++ b/src/util/repeat_bytes.rs
@@ -1,5 +1,5 @@
+use crate::Read;
 use void::Void;
-use Read;
 
 /// Reader repeating a sequence of bytes infinitely.
 pub struct RepeatBytes<B> {
@@ -11,7 +11,7 @@ impl<B: AsRef<[u8]>> Read for RepeatBytes<B> {
     type ReadError = Void;
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
-        use ::core::cmp::min;
+        use core::cmp::min;
         let len = buf.len();
         let bytes = self.bytes.as_ref();
 

--- a/src/util/restarting.rs
+++ b/src/util/restarting.rs
@@ -1,6 +1,6 @@
-use error::{IntoIntrError, IntrError};
-use Read;
-use Write;
+use crate::error::{IntoIntrError, IntrError};
+use crate::Read;
+use crate::Write;
 
 /// Restarts all interrupted operations.
 ///

--- a/src/util/restarting.rs
+++ b/src/util/restarting.rs
@@ -1,6 +1,6 @@
+use error::{IntoIntrError, IntrError};
 use Read;
 use Write;
-use error::{IntrError, IntoIntrError};
 
 /// Restarts all interrupted operations.
 ///
@@ -8,7 +8,7 @@ use error::{IntrError, IntoIntrError};
 /// will be restarted when wrapped in this type.
 ///
 /// The error types indicate that interrupted error case has been handled.
-pub struct Restarting<T> (T);
+pub struct Restarting<T>(T);
 
 impl<T> Restarting<T> {
     /// Creates restarting IO.
@@ -21,7 +21,9 @@ impl<T> Restarting<T> {
         self.0
     }
 
-    fn restart_call<S, E: IntoIntrError, F: FnMut() -> Result<S, E>>(mut f: F) -> Result<S, E::NonIntr> {
+    fn restart_call<S, E: IntoIntrError, F: FnMut() -> Result<S, E>>(
+        mut f: F,
+    ) -> Result<S, E::NonIntr> {
         loop {
             match f().map_err(IntoIntrError::into_intr_error) {
                 Ok(success) => return Ok(success),
@@ -32,24 +34,33 @@ impl<T> Restarting<T> {
     }
 }
 
-impl<R> Read for Restarting<R> where R: Read, R::ReadError: IntoIntrError {
+impl<R> Read for Restarting<R>
+where
+    R: Read,
+    R::ReadError: IntoIntrError,
+{
     type ReadError = <<R as Read>::ReadError as IntoIntrError>::NonIntr;
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
-        Self::restart_call(|| self.0.read(buf))    
+        Self::restart_call(|| self.0.read(buf))
     }
 }
 
-impl<W> Write for Restarting<W> where W: Write, W::WriteError: IntoIntrError, W::FlushError: IntoIntrError {
+impl<W> Write for Restarting<W>
+where
+    W: Write,
+    W::WriteError: IntoIntrError,
+    W::FlushError: IntoIntrError,
+{
     type WriteError = <<W as Write>::WriteError as IntoIntrError>::NonIntr;
     type FlushError = <<W as Write>::FlushError as IntoIntrError>::NonIntr;
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::WriteError> {
-        Self::restart_call(|| self.0.write(buf))    
+        Self::restart_call(|| self.0.write(buf))
     }
 
     fn flush(&mut self) -> Result<(), Self::FlushError> {
-        Self::restart_call(|| self.0.flush())    
+        Self::restart_call(|| self.0.flush())
     }
 
     fn size_hint(&mut self, bytes: usize) {

--- a/src/util/sink.rs
+++ b/src/util/sink.rs
@@ -1,5 +1,5 @@
+use crate::Write;
 use void::Void;
-use Write;
 
 /// Silently drops everything that is written to it.
 pub struct Sink;

--- a/src/util/sink.rs
+++ b/src/util/sink.rs
@@ -1,5 +1,5 @@
-use Write;
 use void::Void;
+use Write;
 
 /// Silently drops everything that is written to it.
 pub struct Sink;
@@ -7,7 +7,7 @@ pub struct Sink;
 impl Write for Sink {
     type WriteError = Void;
     type FlushError = Void;
-    
+
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::WriteError> {
         Ok(buf.len())
     }

--- a/src/util/write_trunc.rs
+++ b/src/util/write_trunc.rs
@@ -38,7 +38,9 @@ impl<W: Write> Write for WriteTrunc<W> {
         self.remaining -= buf.len() as u64;
 
         if buf.len() > 0 {
-            self.writer.write(buf).map(|written| if self.remaining > 0 { written } else { len })
+            self.writer
+                .write(buf)
+                .map(|written| if self.remaining > 0 { written } else { len })
         } else {
             Ok(len)
         }

--- a/src/util/write_trunc.rs
+++ b/src/util/write_trunc.rs
@@ -1,4 +1,4 @@
-use Write;
+use crate::Write;
 
 /// Truncates writing so that at most `n` bytes in total are written into the writer.
 ///


### PR DESCRIPTION
closes #19 

- reformatted code with `cargo fmt`
- fixed compile failures with edition 2018