### PR TITLE
Add mutable slice Read()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,6 +498,15 @@ impl<'a> Read for &'a [u8] {
     }
 }
 
+impl<'a> Read for &'a mut [u8] {
+    type ReadError = Void;
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
+        let mut immutable : &[u8] = self;
+        immutable.read(buf)
+    }
+}
+
 impl<'a> Write for &'a mut [u8] {
     type WriteError = error::BufferOverflow;
     type FlushError = Void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ extern crate void;
 #[cfg(feature = "std")]
 pub mod std_impls;
 
+use core::mem::take;
+
 pub mod bufio;
 pub mod error;
 pub mod ext;
@@ -502,8 +504,10 @@ impl<'a> Read for &'a mut [u8] {
     type ReadError = Void;
 
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::ReadError> {
-        let mut immutable : &[u8] = self;
-        immutable.read(buf)
+        let mut immutable: &[u8] = self;
+        let amt = immutable.read(buf)?;
+        *self = &mut take(self)[amt..];
+        Ok(amt)
     }
 }
 


### PR DESCRIPTION
Adds a Read() impl for mutable u8 slices as well. This allows passing slices around for functions with both <T: Read + Write> constraints